### PR TITLE
0.0.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,10 @@ jobs:
           ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,44 +1,43 @@
 name: Lint
 
-on:
-  push
+on: push
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version:
+          ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
           python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      shell: bash
-      run: pip install -r requirements_dev.txt
+      - name: Install dependencies
+        shell: bash
+        run: pip install -r requirements_dev.txt
 
-    - name: Install the library
-      shell: bash
-      run: pip install .
+      - name: Install the library
+        shell: bash
+        run: pip install .
 
-    - name: Run mypy
-      shell: bash
-      run: mypy displayhooks --strict
+      - name: Run mypy
+        shell: bash
+        run: mypy displayhooks --strict
 
-    - name: Run mypy for tests
-      shell: bash
-      run: mypy tests
+      - name: Run mypy for tests
+        shell: bash
+        run: mypy tests
 
-    - name: Run ruff
-      shell: bash
-      run: ruff check displayhooks
+      - name: Run ruff
+        shell: bash
+        run: ruff check displayhooks
 
-    - name: Run ruff for tests
-      shell: bash
-      run: ruff check tests
+      - name: Run ruff for tests
+        shell: bash
+        run: ruff check tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-            python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -31,17 +31,18 @@ jobs:
         run: pip list
 
       - name: Run tests and show coverage on the command line
-        run: coverage run --source=displayhooks --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=100
-
-      - name: Upload reports to codecov
-        env:
-          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
-        if: runner.os == 'Linux'
         run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          find . -iregex "codecov.*"
-          chmod +x codecov
-          ./codecov -t ${CODECOV_TOKEN}
+          coverage run --source=displayhooks --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=100
+          coverage xml
+
+      - name: Upload coverage to Coveralls
+        if: runner.os == 'Linux'
+        env:
+          COVERALLS_REPO_TOKEN: ${{secrets.COVERALLS_REPO_TOKEN}}
+        uses: coverallsapp/github-action@v2
+        with:
+          format: cobertura
+          file: coverage.xml
 
       - name: Run tests and show the branch coverage on the command line
         run: coverage run --branch --source=displayhooks --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=100

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -1,48 +1,47 @@
 name: Tests
 
-on:
-  push
+on: push
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version:
+          ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
           python-version: ${{ matrix.python-version }}
 
-    - name: Install the library
-      shell: bash
-      run: pip install .
+      - name: Install the library
+        shell: bash
+        run: pip install .
 
-    - name: Install dependencies
-      shell: bash
-      run: pip install -r requirements_dev.txt
+      - name: Install dependencies
+        shell: bash
+        run: pip install -r requirements_dev.txt
 
-    - name: Print all libs
-      shell: bash
-      run: pip list
+      - name: Print all libs
+        shell: bash
+        run: pip list
 
-    - name: Run tests and show coverage on the command line
-      run: coverage run --source=displayhooks --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=100
+      - name: Run tests and show coverage on the command line
+        run: coverage run --source=displayhooks --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=100
 
-    - name: Upload reports to codecov
-      env:
-        CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
-      if: runner.os == 'Linux'
-      run: |
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        find . -iregex "codecov.*"
-        chmod +x codecov
-        ./codecov -t ${CODECOV_TOKEN}
+      - name: Upload reports to codecov
+        env:
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+        if: runner.os == 'Linux'
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          find . -iregex "codecov.*"
+          chmod +x codecov
+          ./codecov -t ${CODECOV_TOKEN}
 
-    - name: Run tests and show the branch coverage on the command line
-      run: coverage run --branch --source=displayhooks --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=100
+      - name: Run tests and show the branch coverage on the command line
+        run: coverage run --branch --source=displayhooks --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=100

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -12,9 +12,9 @@ jobs:
           ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ It's a micro library for manipulating [`sys.displayhook`](https://docs.python.or
 
 When you need to change the standard behavior of `displayhook`, with this library you will do it:
 
-- declaratively
-- compactly
-- beautifully
+- 💎 declaratively
+- 🫥 compactly
+- 🌞 beautifully
 
 
 ## Table of contents

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Downloads](https://static.pepy.tech/badge/displayhooks/month)](https://pepy.tech/project/displayhooks)
 [![Downloads](https://static.pepy.tech/badge/displayhooks)](https://pepy.tech/project/displayhooks)
-[![codecov](https://codecov.io/gh/pomponchik/displayhooks/graph/badge.svg?token=UXXTj1AIcT)](https://codecov.io/gh/pomponchik/displayhooks)
+[![Coverage Status](https://coveralls.io/repos/github/pomponchik/displayhooks/badge.svg?branch=main)](https://coveralls.io/github/pomponchik/displayhooks?branch=main)
 [![Lines of code](https://sloc.xyz/github/pomponchik/displayhooks/?category=code)](https://github.com/boyter/scc/)
 [![Hits-of-Code](https://hitsofcode.com/github/pomponchik/displayhooks?branch=main)](https://hitsofcode.com/github/pomponchik/displayhooks/view?branch=main)
 [![Test-Package](https://github.com/pomponchik/displayhooks/actions/workflows/tests_and_coverage.yml/badge.svg)](https://github.com/pomponchik/metronomes/actions/workflows/tests_and_coverage.yml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'displayhooks'
-version = '0.0.4'
+version = '0.0.5'
 authors = [
   { name='Evgeniy Blinov', email='zheni-b@yandex.ru' },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
   'Programming Language :: Python :: 3.13',
+  'Programming Language :: Python :: 3.14',
   'License :: OSI Approved :: MIT License',
   'Topic :: Software Development :: Libraries',
   'Intended Audience :: Developers',

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pytest==8.4.2
+pytest==8.3.5
 pytest-timeout==2.2.0
 coverage==7.6.1
 twine==6.1.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pytest==9.0.1
+pytest==8.4.2
 pytest-timeout==2.2.0
 coverage==7.6.1
 twine==6.1.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pytest==7.4.3
+pytest==9.0.1
 pytest-timeout==2.2.0
 coverage==7.6.1
 twine==6.1.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,4 @@ build==1.2.2.post1
 ruff==0.9.9
 mypy==1.14.1
 mutmut==3.2.3
-full_match==0.0.2
+full_match==0.0.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ coverage==7.6.1
 twine==6.1.0
 wheel==0.41.2
 build==1.2.2.post1
-ruff==0.9.9
+ruff==0.14.5
 mypy==1.14.1
 mutmut==3.2.3
 full_match==0.0.3

--- a/tests/test_autorestore.py
+++ b/tests/test_autorestore.py
@@ -1,13 +1,14 @@
 import sys
 
 import pytest
-import full_match
+from full_match import match
 
 from displayhooks import autorestore_displayhook
 
 
 def test_restore():
     hook_before_declaration = sys.displayhook
+
     @autorestore_displayhook
     def do_something():
         sys.displayhook = 5
@@ -22,14 +23,15 @@ def test_restore():
 
 def test_restore_after_exception():
     hook_before_declaration = sys.displayhook
+
     @autorestore_displayhook
     def do_something():
         sys.displayhook = 5
-        raise ValueError('message')
+        raise ValueError("message")
 
     hook_before_calling = sys.displayhook
 
-    with pytest.raises(ValueError, match=full_match('message')):
+    with pytest.raises(ValueError, match=match("message")):
         do_something()
 
     assert hook_before_declaration is sys.displayhook


### PR DESCRIPTION
A purely technical update, with no new functionality.

- Added full support for `Python 3.14`.
- `Python 3.14` and `3.14 free threading` runners added to CI. Also updated versions of some of the Github Actions used.
- The provider of the test coverage display changed to `Coveralls`.
- Updated some dev-dependencies.